### PR TITLE
autofill of all spotify genres

### DIFF
--- a/public-static/js/vendor/select2.js
+++ b/public-static/js/vendor/select2.js
@@ -1,5 +1,4 @@
 
-// In your Javascript (external .js resource or <script> tag)
 $(document).ready(function() {
     
   $(".js-example-data-ajax").select2({
@@ -11,8 +10,7 @@ $(document).ready(function() {
       data: function (params) {
         return {
           q: params.term, // search term
-        };
-        
+        }; 
       },
       processResults: function (data, params) {
         //this logs params in console
@@ -20,42 +18,34 @@ $(document).ready(function() {
         //this logs from url + /api/genres
         var genreList = [];
         var id;
+
+$(".select2-search__field").keyup(function autoFill() {
+
+    $("#mapInfoDiv").empty();
+
         for (id=1; id < data.results.length - 1; id++){
-          genreList.push(data.results[id].text);
-          
+         
+          // genreList.push(data.results[id].text);
+          const indexOfFirst = (data.results[id].text).indexOf(params.term);
+        if(((data.results[id].text).match(params.term))){
           $("#mapInfoDiv").append(`<option>${data.results[id].text}</option>`);
-          
         }
-        
-        //This logs the whole genreList
-        console.log(genreList);
-        var letterPoint = $(params).val().length;
-        
-
-
-
+          // $("#mapInfoDiv").append(`<option>${data.results[id].text}</option>`);
     
-        
-           
+        }
+        if (
+            console.log(data.results[id].text.split('=')[1])); 
+          $(".js-example-matcher").select2({
+            matcher: autoFill
+          });           
+    });
 
-
-
-
-
-
-
-
-
-
-
-        
         // parse the results into the format expected by Select2
         // since we are using custom formatting functions we do not need to
         // alter the remote JSON data, except to indicate that infinite
         // scrolling can be used
         params.page = params.page || 1;
   
-
         return {
           results: data.results,
           pagination: {
@@ -71,34 +61,16 @@ $(document).ready(function() {
     templateSelection: formatRepoSelection
   
   });
-  
+  // This are left over from documentation /setup... 
+  // They are currently blocking the dropdown menu for selections, and
+  // this is fine because I haven't configured that yet. I do like the
+  // autopost to sidediv, so the exact presentation of these query
+  // autofills is yet to be determined...
   function formatRepo (repo) {
     if (repo.loading) {
       return repo.text;
     }
   
-    // var $container = $(
-    //   "<div class='select2-result-repository clearfix'>" +
-    //     "<div class='select2-result-repository__meta'>" +
-    //       "<div class='select2-result-repository__title'></div>" +
-    //       "<div class='select2-result-repository__description'></div>" +
-    //       "<div class='select2-result-repository__statistics'>" +
-    //         "<div class='select2-result-repository__forks'><i class='fa fa-flash'></i> </div>" +
-    //         "<div class='select2-result-repository__stargazers'><i class='fa fa-star'></i> </div>" +
-    //         "<div class='select2-result-repository__watchers'><i class='fa fa-eye'></i> </div>" +
-    //       "</div>" +
-    //     "</div>" +
-    //   "</div>"
-    // );
-    console.log(repo);
-  
-    $container.find(".select2-result-repository__title").text(data.results[id].text);
-    $container.find(".select2-result-repository__description").text(repo.description);
-    $container.find(".select2-result-repository__forks").append(repo.forks_count + " Forks");
-    $container.find(".select2-result-repository__stargazers").append(repo.stargazers_count + " Stars");
-    $container.find(".select2-result-repository__watchers").append(repo.watchers_count + " Watchers");
-  
-    return $container;
   }
   
   function formatRepoSelection (repo) {


### PR DESCRIPTION
the search bar is currently calling up all matching spotify genres in the scrolling side div on the right... I commented out the client-side array "genreList" & I left in some documentation functions (formatRepo and formatSelectionRepo) that are currently stopping the Select2 scrollbar dropdown functionality... we'll have to decide how we want to present the results of these searches.